### PR TITLE
Fixed duck speed change with rounds

### DIFF
--- a/Assets/Scripts/Managers/RoundManager.cs
+++ b/Assets/Scripts/Managers/RoundManager.cs
@@ -202,9 +202,9 @@ public class RoundManager : MonoBehaviour
     void setSpeedMult()
     {
         if (_roundCount <= 8)
-            duckSpeedMult = 1 + (_roundCount / 8);
+            duckSpeedMult = 1 + ((float)_roundCount / 8);
         else if (_roundCount <= 12)
-            duckSpeedMult = 2 + ((_roundCount % 8) / 4);
+            duckSpeedMult = 2 + (((float)_roundCount % 8) / 4);
         else
             duckSpeedMult = 3;
     }

--- a/Assets/Scripts/Managers/SpawnManager.cs
+++ b/Assets/Scripts/Managers/SpawnManager.cs
@@ -23,7 +23,7 @@ public class SpawnManager : MonoBehaviour
 
         // update the round manager and give it the duck and ducks name
         Duck2.GetComponent<DuckScript>().duckName = "Duck2";
-        Duck2.GetComponent<DuckScript>().speedMult = rm.duckSpeedMult;
+        Duck2.GetComponent<DuckScript>().updateSpeed(rm.duckSpeedMult);
         rm.ducks++; ;
         rm.duckObj.Add(Duck2.GetComponent<DuckScript>().duckName, Duck2);
 
@@ -75,7 +75,7 @@ public class SpawnManager : MonoBehaviour
         if (rm.firstRound)
             rm.firstRound = false;
         Duck1.GetComponent<DuckScript>().duckName = "Duck1";
-        Duck1.GetComponent<DuckScript>().speedMult = rm.duckSpeedMult;
+        Duck1.GetComponent<DuckScript>().updateSpeed(rm.duckSpeedMult);
         rm.ducks++;
         rm.duckObj.Add(Duck1.GetComponent<DuckScript>().duckName, Duck1);
 

--- a/Assets/Scripts/Mechanics/DuckScript.cs
+++ b/Assets/Scripts/Mechanics/DuckScript.cs
@@ -18,8 +18,8 @@ public class DuckScript : MonoBehaviour
     bool isDead = false;
     bool missed = false;
 
-    public float speed;
-    public float speedMult;
+    [SerializeField]float speed;
+    float speedMult;
 
     public bool isDodgey;
 
@@ -90,7 +90,6 @@ public class DuckScript : MonoBehaviour
             horizontalMovement = .4f;
         }
 
-        speedMult = 1;
         speed = baseSpeed * speedMult;
 
         moveDirection = new Vector2(horizontalMovement, verticalMovement);


### PR DESCRIPTION
--Summary
- Cast int as float for roundcount division
- Called update speed function in spawnManager
- InitializeSpeed in DuckScript cancelled out the speedMult change in spawnManager